### PR TITLE
feat: rails-18nの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'thruster', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 gem 'rack-cors'
 
+gem 'rails-i18n', '~> 8.0.0' # For Rails >= 8.0.0
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.0.1)
       actionpack (= 8.0.1)
       activesupport (= 8.0.1)
@@ -391,6 +394,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rack-cors
   rails (~> 8.0.1)
+  rails-i18n (~> 8.0.0)
   rspec-rails
   rubocop
   rubocop-performance

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module BackpackerBackendPg
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
+    config.i18n.default_locale = :ja
 
     config.generators do |g|
       g.test_framework :rspec,


### PR DESCRIPTION
- rails-i18nの追加
- configのdefaultをjaに修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced internationalization support to improve the user experience.
	- The application now defaults to Japanese, offering a more localized interface for Japanese-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->